### PR TITLE
Bumped version to support laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x"
+        "illuminate/support": "~4.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Laravel 4.2 was just [released](http://laravel.com/docs/releases?version=4.2), so this package didn't install with the latest version, so I bumped the version of illuminate support to make it compatible, did a quick review on the dependencies and doesn't seems to break anything.
